### PR TITLE
RHINENG-18130: Provide Containerfile path for publish

### DIFF
--- a/.github/workflows/container-publish.yaml
+++ b/.github/workflows/container-publish.yaml
@@ -81,6 +81,7 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           context: .
+          file: ./Containerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
* Specify the Containerfile path (see https://github.com/docker/build-push-action?tab=readme-ov-file#customizing)