### PR TITLE
feat: identity handling for UI requests

### DIFF
--- a/identity.pl
+++ b/identity.pl
@@ -4,21 +4,6 @@ use JSON::PP;
 use MIME::Base64;
 
 sub set_identity_header {
-    my $cert_template = {
-        'identity' => {
-            'org_id' => '',
-            'internal' => {
-                'org_id' => ''
-            },
-            'type' => 'System',
-            'auth_type' => 'cert-auth',
-            'system' => {
-                'cn' => '',
-                'cert_type' => 'satellite'
-            }
-        }
-    };
-
     my $identity;
     my $r = shift;
 
@@ -47,12 +32,22 @@ sub set_identity_header {
         return undef;
     }
 
-    $cert_template->{identity}->{system}->{cn} = $cn;
-    $cert_template->{identity}->{org_id} = $org_id;
-    $cert_template->{identity}->{internal}->{org_id} = $org_id;
-    $identity = encode_base64(encode_json($cert_template), '');
+    $identity = {
+        'identity' => {
+            'org_id' => $org_id,
+            'internal' => {
+                'org_id' => $org_id
+            },
+            'type' => 'System',
+            'auth_type' => 'cert-auth',
+            'system' => {
+                'cn' => $cn,
+                'cert_type' => 'satellite'
+            }
+        }
+    };
 
-    return $identity;
+    return encode_base64(encode_json($identity), '');
 }
 
 1;


### PR DESCRIPTION
Identity within the gateway will be handled depending on whether the requests are being proxied/forwarded (i.e. from systems) or whether there is direct request to provide data for the end user.

Proxied/forwarded requests are required to include [`Forwarded`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Forwarded) header (RFC 7239). Those would get a System identity with `cn` populated from the certificate's `CN` and `org_id` from `O`.

Requests going directly to the gateway (i.e. to provide data for the end user), will get a User identity of type jwt-token. Username is set to the value of `CN` from the client's certificate and `org_id` from `O`.

Refs:
* Identity schema: https://github.com/RedHatInsights/identity-schemas/blob/main/3scale/schema.json