### PR TITLE
feat: increase proxy buffers for the relay

### DIFF
--- a/nginx/smart-proxy-relay/buffers.conf
+++ b/nginx/smart-proxy-relay/buffers.conf
@@ -1,0 +1,2 @@
+proxy_buffers   4 32k;
+proxy_buffer_size 32k;

--- a/nginx/smart-proxy-relay/locations.conf
+++ b/nginx/smart-proxy-relay/locations.conf
@@ -1,4 +1,5 @@
 location / {
+    include /etc/nginx/smart-proxy-relay/buffers.conf;
     include /etc/nginx/smart-proxy-relay/relay.conf;
 
     proxy_ssl_certificate         /etc/nginx/smart-proxy-relay/certs/proxy.crt;


### PR DESCRIPTION
Increases the proxy buffers of the smart proxy relay to satisfy foreman's (header) responses.

This should overcome the error like:
```
[error] 3#3: *9 upstream sent too big header while reading response header from upstream
```