### PR TITLE
feat: utilize Forwarded for

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ To test out the connection with curl:
 curl -v -4 --key certs/client.key --cert certs/client.crt --cacert certs/ca.crt https://localhost:8443
 ```
 
+### Testing
+
+Identity generation can be tested out by a request to `/_identity` which would return the base64 version
+of the identity header.
+
+```bash
+curl -v -4 --key certs/client.key --cert certs/client.crt --cacert certs/ca.crt https://localhost:8443/_identity | base64 -d
+```
+
+and with `Forwarded` header:
+
+```bash
+curl -v -4 -H 'Forwarded: for="_uuid"' --key certs/client.key --cert certs/client.crt --cacert certs/ca.crt https://localhost:8443/_identity | base64 -d
+```
+
 
 ### Smart Proxy Relay
 

--- a/identity.pl
+++ b/identity.pl
@@ -57,7 +57,16 @@ sub set_identity_header {
             }
         };
     } else {
-        # Use System identity for forwarded requests
+        # Use System identity for forwarded requests and utilize the for value
+        # that should include system's UUID (i.e. subscription id).
+        my $owner_id;
+        if ($forwarded =~ /for="?_([^,;"]+)"?/i) {
+            $owner_id = $1;
+        } else {
+            $r->log_error(0, "Missing Forwared for header value (as per RFC7239): $forwarded");
+            return undef;
+        }
+
         $identity = {
             'identity' => {
                 'org_id' => $org_id,
@@ -67,7 +76,7 @@ sub set_identity_header {
                 'type' => 'System',
                 'auth_type' => 'cert-auth',
                 'system' => {
-                    'cn' => $cn,
+                    'cn' => $owner_id,
                     'cert_type' => 'satellite'
                 }
             }

--- a/nginx/common.d/50-common-locations.conf
+++ b/nginx/common.d/50-common-locations.conf
@@ -2,6 +2,10 @@ location / {
     return 200 'OK';
 }
 
+location = /_identity {
+    return 200 $identity;
+}
+
 location /api/ingress {
     proxy_pass http://$ingress;
 }


### PR DESCRIPTION
The Forwarded header (RFC7239) is parsed to get a system's UUID (i.e.
subscription id) that is included witin the `for=` as an obfuscated value.
The value is used in the identity generation for a system identity
within the `cn`.

Example of the header:
```
Forwarded: for="_00000000-00000000-00000000-00000000"
```

RHINENG-19457