### PR TITLE
feat: associate identity and expose vmaas-reposcan sync API

### DIFF
--- a/identity.pl
+++ b/identity.pl
@@ -34,28 +34,44 @@ sub set_identity_header {
 
     my $forwarded = $r->header_in("Forwarded"); # RFC 7239
     if (!$forwarded || $forwarded eq "") {
-        # Use User identity for non-forwarded requests
-        $identity = {
-            'identity' => {
-                'auth_type' => 'jwt-auth',
-                'org_id' => $org_id,
-                'internal' => {
-                    'org_id' => $org_id
-                },
-                'type' => 'User',
-                'user' => {
-                    'email' => 'iop-gateway@example.com',
-                    'first_name' => 'First',
-                    'is_active' => JSON::PP::true,
-                    'is_internal' => JSON::PP::true,
-                    'is_org_admin' => JSON::PP::false,
-                    'last_name' => 'Last',
-                    'locale' => 'en_US',
-                    'user_id' => '1',
-                    'username' => $cn
+        my $identity_type = $r->variable('identity_type');
+        if ($identity_type eq "associate") {
+            $identity = {
+                'identity' => {
+                    'type' => 'Associate',
+                    'auth_type' => 'saml-auth',
+                    'associate' => {
+                        'email' => 'iop-gateway@example.com',
+                        'Role' => [],
+                        'subject_dn' => 'iop-gateway'
+                    }
                 }
-            }
-        };
+            };
+        } else {
+            # Use User identity for non-forwarded requests with no forced identity-type set
+            $identity = {
+                'identity' => {
+                    'auth_type' => 'jwt-auth',
+                    'org_id' => $org_id,
+                    'internal' => {
+                        'org_id' => $org_id
+                    },
+                    'type' => 'User',
+                    'user' => {
+                        'email' => 'iop-gateway@example.com',
+                        'first_name' => 'First',
+                        'is_active' => JSON::PP::true,
+                        'is_internal' => JSON::PP::true,
+                        'is_org_admin' => JSON::PP::false,
+                        'last_name' => 'Last',
+                        'locale' => 'en_US',
+                        'user_id' => '1',
+                        'username' => $cn
+                    }
+                }
+            };
+
+        }
     } else {
         # Use System identity for forwarded requests and utilize the for value
         # that should include system's UUID (i.e. subscription id).

--- a/nginx/common.d/10-service-variables.conf
+++ b/nginx/common.d/10-service-variables.conf
@@ -3,3 +3,4 @@ set $advisor "iop-service-advisor-backend-api:8000";
 set $hbi "iop-core-host-inventory-api:8081";
 set $remediations "iop-service-remediations-api:9002";
 set $vulnerability "iop-service-vuln-manager:8000";
+set $vmaas_reposcan "iop-service-vmaas-reposcan:8000";

--- a/nginx/common.d/50-common-locations.conf
+++ b/nginx/common.d/50-common-locations.conf
@@ -34,6 +34,11 @@ location /api/vulnerability {
     proxy_pass http://$vulnerability;
 }
 
+location /api/vmaas-reposcan/ {
+    set $identity_type "associate";
+    proxy_pass http://$vmaas_reposcan/api/;
+}
+
 location /r/insights/uploads {
     rewrite ^/r/insights/uploads(?:/.*)?$ /api/ingress/v1/upload break;
     proxy_pass http://$ingress;


### PR DESCRIPTION
Creates a new identity type Associate that can be set manually for locations by setting `set $identity_type "associate"`. It will work for all non-forwarded requests.

```
{
    "identity": {
        "type": "Associate",
        "associate": {
            "Role": [],
            "subject_dn": "iop-gateway",
            "email": "iop-gateway@example.com"
        },
        "auth_type": "saml-auth"
    }
}
```

Exposes VMaaS reposync sync endpoints via:
```
/api/vmaas-reposcan/v1/sync
```

cc @jdobes

RHINENG-19882