### PR TITLE
feat: route /api/compliance to compliance-backend

### DIFF
--- a/nginx/common.d/10-service-variables.conf
+++ b/nginx/common.d/10-service-variables.conf
@@ -4,3 +4,4 @@ set $hbi "iop-core-host-inventory-api:8081";
 set $remediations "iop-service-remediations-api:9002";
 set $vulnerability "iop-service-vuln-manager:8000";
 set $vmaas_reposcan "iop-service-vmaas-reposcan:8000";
+set $compliance "iop-service-compliance-backend-api:8000";

--- a/nginx/common.d/50-common-locations.conf
+++ b/nginx/common.d/50-common-locations.conf
@@ -34,6 +34,10 @@ location /api/vulnerability {
     proxy_pass http://$vulnerability;
 }
 
+location /api/compliance {
+    proxy_pass http://$compliance;
+}
+
 location ~ ^/api/vmaas-reposcan/(.*)$ {
     set $identity_type "associate";
     proxy_pass http://$vmaas_reposcan/api/$1;


### PR DESCRIPTION
The gateway needs to forward compliance API requests to the backend container to integrate compliance-backend
into the IoP stack.

Ref: RHINENG-28571