### PR TITLE
fix: stop nginx from writing compile-time default error.log

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -5,18 +5,16 @@ USER 0
 RUN dnf install -y nginx-mod-http-perl perl-JSON-PP \
     && dnf clean all
 
-# Create directories and set permissions
+# Create directories and set permissions (omit /var/log/nginx so nginx cannot create default error.log)
 RUN mkdir -p /usr/share/nginx/html/static/release \
     && mkdir -p /run \
     && mkdir -p /etc/nginx/certs \
-    && mkdir -p /var/log/nginx \
     && mkdir -p /var/lib/nginx/tmp/client_body \
-    && chmod 770 /var/log/nginx \
     && chmod -R 750 /var/lib/nginx
 
 COPY identity.pl /etc/nginx/perl/identity.pl
 
-RUN chown -R nginx:nginx /usr/share/nginx/html /etc/nginx/certs /var/log/nginx /etc/nginx /var/lib/nginx /run
+RUN chown -R nginx:nginx /usr/share/nginx/html /etc/nginx/certs /etc/nginx /var/lib/nginx /run
 
 COPY nginx/ /etc/nginx/
 
@@ -24,4 +22,4 @@ USER nginx
 
 EXPOSE 8443/tcp
 
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["nginx", "-g", "daemon off; error_log /dev/stderr info;"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,5 @@
 load_module /usr/lib64/nginx/modules/ngx_http_perl_module.so;
 
-user nginx;
 worker_processes auto;
 error_log /dev/stdout info;
 pid /run/nginx.pid;


### PR DESCRIPTION
### What does this implement/fix?

Fixes [SAT-47490](https://redhat.atlassian.net/browse/SAT-47490), where nginx created `/var/log/nginx/error.log` during early startup before the configured `error_log` directive took effect.

This change:
- Redirects early startup logs to `stderr` via the container `CMD`.
- Removes the unused `user nginx;` directive, which emitted warnings when running as a non-root user and caused those warnings to be written to the default log path.
- Stops creating a writable `/var/log/nginx` directory, preventing nginx from creating an empty default `error.log` in the container image.

[SAT-47490]: https://redhat.atlassian.net/browse/SAT-47490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ